### PR TITLE
Add pref to override the user agent for pocket analysis.

### DIFF
--- a/src/variations.json
+++ b/src/variations.json
@@ -7,7 +7,9 @@
         "browser.search.param.google_channel_row": "crow",
         "network.cookie.cookieBehavior": 4,
         "urlclassifier.trackingAnnotationTable": "test-track-simple,base-track-digest256",
-        "browser.contentblocking.category": "custom"
+        "browser.contentblocking.category": "custom",
+        "general.useragent.override.getpocket.com": "Mozilla/5.0 Gecko/20100101 Firefox Study-ETP-Off",
+        "general.useragent.override.pocket.com": "Mozilla/5.0 Gecko/20100101 Firefox Study-ETP-Off"
       },
       "expectNonDefaults": [
         "browser.contentblocking.category"
@@ -17,7 +19,9 @@
         "browser.search.param.google_channel_row",
         "network.cookie.cookieBehavior",
         "urlclassifier.trackingAnnotationTable",
-        "browser.contentblocking.category"
+        "browser.contentblocking.category",
+        "general.useragent.override.getpocket.com",
+        "general.useragent.override.pocket.com"
       ],
       "resetValues": {
       }
@@ -32,7 +36,9 @@
         "browser.search.param.google_channel_row": "trow",
         "network.cookie.cookieBehavior": 4,
         "urlclassifier.trackingAnnotationTable": "test-track-simple,base-track-digest256",
-        "browser.contentblocking.category": "custom"
+        "browser.contentblocking.category": "custom",
+        "general.useragent.override.getpocket.com": "Mozilla/5.0 Gecko/20100101 Firefox Study-ETP-On",
+        "general.useragent.override.pocket.com": "Mozilla/5.0 Gecko/20100101 Firefox Study-ETP-On"
       },
       "expectNonDefaults": [
         "browser.contentblocking.category"
@@ -42,7 +48,9 @@
         "browser.search.param.google_channel_row",
         "network.cookie.cookieBehavior",
         "urlclassifier.trackingAnnotationTable",
-        "browser.contentblocking.category"
+        "browser.contentblocking.category",
+        "general.useragent.override.getpocket.com",
+        "general.useragent.override.pocket.com"
       ],
       "resetValues": {
       }


### PR DESCRIPTION

@tanvihacks
Should we filter out users who have changed this value before the study starts? As it stands, this is expecting users who have not set this pref, we need to add that to the requirements in experimenter.